### PR TITLE
Bug fix/better 0.35 emulation

### DIFF
--- a/Client.cs
+++ b/Client.cs
@@ -70,12 +70,8 @@ namespace PokemonGo.RocketAPI
         internal long InventoryLastUpdateTimestamp { get; set; }
         internal Platform Platform { get; set; }
         internal uint AppVersion { get; set; }
-
-        public static long GetCurrentTimeMillis()
-        {
-            return DateTime.UtcNow.ToUnixTime();
-        }
-
+        internal long StartTime { get; set; }
+        
         private WebProxy InitProxy()
         {
             if (!Settings.UseProxy) return null;

--- a/Helpers/CommonRequest.cs
+++ b/Helpers/CommonRequest.cs
@@ -141,7 +141,7 @@ namespace PokemonGo.RocketAPI.Helpers
                         //getInventoryResponse.MergeFrom(data);
 
                         // Update inventory timestamp
-                        client.InventoryLastUpdateTimestamp = Client.GetCurrentTimeMillis();
+                        client.InventoryLastUpdateTimestamp = Utils.GetTime(true);
 
                         break;
                     case RequestType.DownloadSettings:

--- a/Helpers/RequestBuilder.cs
+++ b/Helpers/RequestBuilder.cs
@@ -9,6 +9,7 @@ using POGOProtos.Networking.Platform;
 using POGOProtos.Networking.Platform.Requests;
 using POGOProtos.Networking.Requests;
 using POGOProtos.Enums;
+using Troschuetz.Random;
 
 #endregion
 
@@ -22,6 +23,7 @@ namespace PokemonGo.RocketAPI.Helpers
         private static int  Client_3500_InitialRequestIdConstant_Ios = 16807; //0x000041A7
 
         private static readonly Random RandomDevice = new Random();
+        private static readonly TRandom TRandomDevice = new TRandom();
         private readonly double _altitude;
         private readonly AuthTicket _authTicket;
         private readonly string _authToken;
@@ -35,6 +37,8 @@ namespace PokemonGo.RocketAPI.Helpers
         private readonly ISettings _settings;
         
         private static long NextRequestId;
+        private float _course = RandomDevice.Next(0, 360);
+        private int _token2 = RandomDevice.Next(1, 59);
         
         public RequestBuilder(Client client, string authToken, AuthType authType, double latitude, double longitude, double altitude, float speed,
             ISettings settings, AuthTicket authTicket = null)
@@ -47,13 +51,14 @@ namespace PokemonGo.RocketAPI.Helpers
             _altitude = altitude;
 
             // Add small variance to speed.
-            _speed = speed + ((float)Math.Round(GenRandom(-1, 1), 7)); 
+            _speed = speed + ((float)Math.Round(GenRandom(-1, 1), 7));
 
             // If speed is 0 or negative, make it random.
             if (_speed <= 0)
-                _speed = (float)Math.Round(GenRandom(0.2, 4.25), 7); // Range 0.2 - 4.25
+                _speed = (float)TRandomDevice.Triangular(0.1, 3.1, .8);
 
-            _horizontalAccuracy = (float) Math.Round(GenRandom(50, 250), 7);
+            _horizontalAccuracy = TRandomDevice.Choice(new List<double>(new double[] { 5, 5, 5, 5, 10, 10, 10, 30, 30, 50, 65, GenRandom(66, 80) }));
+
             _settings = settings;
             _authTicket = authTicket;
 
@@ -141,21 +146,21 @@ namespace PokemonGo.RocketAPI.Helpers
                 SensorInfo = new Signature.Types.SensorInfo
                 {
                     TimestampSnapshot = (ulong) (Utils.GetTime(true) - _client.StartTime - RandomDevice.Next(100, 500)),
-                    LinearAccelerationX = GenRandom(-0.31110161542892456, 0.1681540310382843),
-                    LinearAccelerationY = GenRandom(-0.6574847102165222, -0.07290205359458923),
-                    LinearAccelerationZ = GenRandom(-0.9943905472755432, -0.7463029026985168),
-                    MagneticFieldX = GenRandom(-0.139084026217, 0.138112977147),
-                    MagneticFieldY = GenRandom(-0.2, 0.19),
-                    MagneticFieldZ = GenRandom(-0.2, 0.4),
+                    LinearAccelerationX = TRandomDevice.Triangular(-3, 1, 0),
+                    LinearAccelerationY = TRandomDevice.Triangular(-2, 3, 0),
+                    LinearAccelerationZ = TRandomDevice.Triangular(-4, 2, 0),
+                    MagneticFieldX = TRandomDevice.Triangular(-50, 50, 0),
+                    MagneticFieldY = TRandomDevice.Triangular(-60, 50, -5),
+                    MagneticFieldZ = TRandomDevice.Triangular(-60, 40, -30),
                     RotationVectorX = GenRandom(-47.149471283, 61.8397789001),
                     RotationVectorY = GenRandom(-47.149471283, 61.8397789001),
                     RotationVectorZ = GenRandom(-47.149471283, 5),
                     GyroscopeRawX = GenRandom(0.0729667818829, 0.0729667818829),
                     GyroscopeRawY = GenRandom(-2.788630499244109, 3.0586791383810468),
                     GyroscopeRawZ = GenRandom(-0.34825887123552773, 0.19347580173737935),
-                    GravityX = GenRandom(-0.9703824520111084, 0.8556089401245117),
-                    GravityY = GenRandom(-1.7470258474349976, 1.4218578338623047),
-                    GravityZ = GenRandom(-0.9681901931762695, 0.8396636843681335),
+                    GravityX = TRandomDevice.Triangular(-1, 1, 0.15),
+                    GravityY = TRandomDevice.Triangular(-1, 1, -.2),
+                    GravityZ = TRandomDevice.Triangular(-1, .7, -0.8),
                     AccelerometerAxes = 3
                 },
                 DeviceInfo = deviceInfo
@@ -163,7 +168,7 @@ namespace PokemonGo.RocketAPI.Helpers
 
             Signature.Types.LocationFix locationFix = new Signature.Types.LocationFix
             {
-                Provider = "fused",
+                Provider = TRandomDevice.Choice(new List<string>(new string[] { "network", "network", "network", "network", "fused" })),
                 Latitude = (float)_latitude,
                 Longitude = (float)_longitude,
                 Altitude = (float)_altitude,
@@ -173,11 +178,26 @@ namespace PokemonGo.RocketAPI.Helpers
                 LocationType = 1
             };
 
+            if (_horizontalAccuracy >= 65)
+            {
+                locationFix.HorizontalAccuracy = (float)TRandomDevice.Choice(new List<double>(new double[] { _horizontalAccuracy, 65, 65, GenRandom(66, 80), 200 }));
+                if (_client.Platform == Platform.Ios)
+                    locationFix.VerticalAccuracy = (float)TRandomDevice.Triangular(35, 100, 65);
+            }
+            else
+            {
+                locationFix.HorizontalAccuracy = (float)_horizontalAccuracy;
+                if (_client.Platform == Platform.Ios)
+                {
+                    if (_horizontalAccuracy > 10)
+                        locationFix.VerticalAccuracy = (float)TRandomDevice.Choice(new List<double>(new double[] { 24, 32, 48, 48, 64, 64, 96, 128 }));
+                    else
+                        locationFix.VerticalAccuracy = (float)TRandomDevice.Choice(new List<double>(new double[] { 3, 4, 6, 6, 8, 12, 24 }));
+                }
+            }
+
             if (_client.Platform == Platform.Ios)
             {
-                // Vertical accuracy is iOS only.
-                locationFix.VerticalAccuracy = (float)Math.Round(GenRandom(10, 12), 7); // Range is 10-12
-
                 if (RandomDevice.NextDouble() > 0.95)
                 {
                     // No reading for roughly 1 in 20 updates
@@ -186,8 +206,10 @@ namespace PokemonGo.RocketAPI.Helpers
                 }
                 else
                 {
+                    _course = (float)TRandomDevice.Triangular(0, 360, _course);
+
                     // Course is iOS only.
-                    locationFix.Course = (float)Math.Round(GenRandom(0, 360), 7); // Range is 0-360
+                    locationFix.Course = _course;
 
                     // Speed is iOS only.
                     locationFix.Speed = _speed;
@@ -222,7 +244,7 @@ namespace PokemonGo.RocketAPI.Helpers
                 Longitude = _longitude, //8
                 Accuracy = _horizontalAccuracy, //9
                 AuthTicket = _authTicket, //11
-                MsSinceLastLocationfix = RandomDevice.Next(800, 1900) //12
+                MsSinceLastLocationfix = (long)TRandomDevice.Triangular(300, 30000, 10000) //12
             };
 
             if (_authTicket != null)
@@ -237,7 +259,7 @@ namespace PokemonGo.RocketAPI.Helpers
                     Token = new RequestEnvelope.Types.AuthInfo.Types.JWT
                     {
                         Contents = _authToken,
-                        Unknown2 = RandomDevice.Next(1,59)
+                        Unknown2 = _token2
                     }
                 }; //10
             }

--- a/Helpers/RequestBuilder.cs
+++ b/Helpers/RequestBuilder.cs
@@ -237,7 +237,7 @@ namespace PokemonGo.RocketAPI.Helpers
                     Token = new RequestEnvelope.Types.AuthInfo.Types.JWT
                     {
                         Contents = _authToken,
-                        Unknown2 = 59
+                        Unknown2 = RandomDevice.Next(1,59)
                     }
                 }; //10
             }

--- a/Helpers/Utils.cs
+++ b/Helpers/Utils.cs
@@ -17,13 +17,13 @@ namespace PokemonGo.RocketAPI.Helpers
             return BitConverter.ToUInt64(bytes, 0);
         }
 
-        public static int GetTime(bool ms = false)
+        public static long GetTime(bool ms = false)
         {
             var timeSpan = DateTime.UtcNow - new DateTime(1970, 1, 1);
 
             if (ms)
-                return (int) Math.Round(timeSpan.TotalMilliseconds);
-            return (int) Math.Round(timeSpan.TotalSeconds);
+                return (long)Math.Round(timeSpan.TotalMilliseconds);
+            return (long)Math.Round(timeSpan.TotalSeconds);
         }
 
         public static uint GenerateLocation1(byte[] authTicket, double lat, double lng, double alt)

--- a/PokemonGo.RocketAPI.csproj
+++ b/PokemonGo.RocketAPI.csproj
@@ -117,6 +117,10 @@
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PommaLabs.Thrower, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2f204b7110a52060, processorArchitecture=MSIL">
+      <HintPath>..\packages\Thrower.3.0.1\lib\net45\PommaLabs.Thrower.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\S2Geometry.1.0.3\lib\portable-net45+wp8+win8\S2Geometry.dll</HintPath>
       <Private>True</Private>
@@ -168,6 +172,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Troschuetz.Random, Version=4.0.3.0, Culture=neutral, PublicKeyToken=2f204b7110a52060, processorArchitecture=MSIL">
+      <HintPath>..\packages\Troschuetz.Random.4.0.5\lib\net45\Troschuetz.Random.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Exceptions\GoogleException.cs" />

--- a/PokemonGo.RocketAPI.csproj
+++ b/PokemonGo.RocketAPI.csproj
@@ -118,7 +118,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="PommaLabs.Thrower, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2f204b7110a52060, processorArchitecture=MSIL">
-      <HintPath>..\packages\Thrower.3.0.1\lib\net45\PommaLabs.Thrower.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Thrower.3.0.1\lib\net45\PommaLabs.Thrower.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -173,7 +173,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Troschuetz.Random, Version=4.0.3.0, Culture=neutral, PublicKeyToken=2f204b7110a52060, processorArchitecture=MSIL">
-      <HintPath>..\packages\Troschuetz.Random.4.0.5\lib\net45\Troschuetz.Random.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Troschuetz.Random.4.0.5\lib\net45\Troschuetz.Random.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Rpc/BaseRpc.cs
+++ b/Rpc/BaseRpc.cs
@@ -23,7 +23,7 @@ namespace PokemonGo.RocketAPI.Rpc
 
         protected RequestBuilder GetRequestBuilder()
         {
-            return new RequestBuilder(Client.AuthToken, Client.AuthType, Client.CurrentLatitude, Client.CurrentLongitude,
+            return new RequestBuilder(Client, Client.AuthToken, Client.AuthType, Client.CurrentLatitude, Client.CurrentLongitude,
                     Client.CurrentAltitude, Client.CurrentSpeed, Client.Settings, Client.AuthTicket);
         }
 

--- a/Rpc/Login.cs
+++ b/Rpc/Login.cs
@@ -44,6 +44,7 @@ namespace PokemonGo.RocketAPI.Rpc
         public async Task DoLogin()
         {
             Client.AuthToken = await _login.GetAccessToken().ConfigureAwait(false);
+            Client.StartTime = Utils.GetTime(true);
 
             await
                 FireRequestBlock(CommonRequest.GetDownloadRemoteConfigVersionMessageRequest(Client))
@@ -55,7 +56,7 @@ namespace PokemonGo.RocketAPI.Rpc
         {
             var requests = CommonRequest.FillRequest(request, Client);
 
-            var serverRequest = GetRequestBuilder().GetInitialRequestEnvelope(requests);
+            var serverRequest = GetRequestBuilder().GetRequestEnvelope(requests);
             var serverResponse = await PostProto<Request>(serverRequest);
 
             if (!string.IsNullOrEmpty(serverResponse.ApiUrl))
@@ -100,7 +101,7 @@ namespace PokemonGo.RocketAPI.Rpc
                 {
                     getInventoryResponse.MergeFrom(responses[3]);
 
-                    Client.InventoryLastUpdateTimestamp = Client.GetCurrentTimeMillis();
+                    Client.InventoryLastUpdateTimestamp = Utils.GetTime(true);
                 }
 
                 var downloadSettingsResponse = new DownloadSettingsResponse();

--- a/Rpc/Player.cs
+++ b/Rpc/Player.cs
@@ -16,7 +16,6 @@ namespace PokemonGo.RocketAPI.Rpc
     {
         public Player(Client client) : base(client)
         {
-            Client = client;
         }
 
         public async Task<PlayerUpdateResponse> UpdatePlayerLocation(double latitude, double longitude, double altitude, float speed)

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="C5" version="2.4.5947.17249" targetFramework="net45" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
@@ -58,5 +57,7 @@
   <package id="System.Threading.Timer" version="4.0.1" targetFramework="net452" />
   <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net452" />
   <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net452" />
+  <package id="Thrower" version="3.0.1" targetFramework="net452" />
+  <package id="Troschuetz.Random" version="4.0.5" targetFramework="net452" />
   <package id="VarintBitConverter" version="1.0.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
General bug fixes and tweaks for 0.35 emulation.
- Bug fix - Generate proper request ids (ported from python api - https://github.com/pogodevorg/pgoapi/pull/130)
- Bug fix - GetTime should return a long not an int.
- Bug fix - Generate proper start time - startTime should be set at startup, not every request.
- Update horizontal accuracy and vertical accuracy
- Update random generator for course and speed
- Location fix provider is randomized now
- Unknown2 is randomized now
- Clean up device info
- Clean up request envelope functions
- Update random generator for sensor info
- Update random generator for MsSinceLastLocationfix
