### PR TITLE
Bugfix/reauthenticate failed

### DIFF
--- a/Exceptions/LoginFailedException.cs
+++ b/Exceptions/LoginFailedException.cs
@@ -6,8 +6,10 @@ using System;
 
 namespace PokemonGo.RocketAPI.Exceptions
 {
+    
     public class LoginFailedException : Exception
     {
+
         public LoginFailedException()
         {
         }
@@ -16,4 +18,17 @@ namespace PokemonGo.RocketAPI.Exceptions
         {
         }
     }
+
+    public class TokenRefreshException : Exception
+    {
+
+        public TokenRefreshException()
+        {
+        }
+
+        public TokenRefreshException(string message) : base(message)
+        {
+        }
+    }
+
 }

--- a/Extensions/HttpClientExtensions.cs
+++ b/Extensions/HttpClientExtensions.cs
@@ -9,6 +9,7 @@ using PokemonGo.RocketAPI.Exceptions;
 using POGOProtos.Networking.Envelopes;
 using System.Collections.Concurrent;
 using System.Threading;
+using Newtonsoft.Json;
 
 #endregion
 
@@ -113,7 +114,7 @@ namespace PokemonGo.RocketAPI.Extensions
                     return await PerformRemoteProcedureCall<TRequest>(client, apiClient, requestEnvelope);
                 case ResponseEnvelope.Types.StatusCode.BadRequest:
                     // Your account may be banned! please try from the official client.
-                    throw new LoginFailedException("Your account may be banned! please try from the official client.");
+                    throw new APIBadRequestException("BAD REQUEST \r\n" + JsonConvert.SerializeObject(requestEnvelope));
                 case ResponseEnvelope.Types.StatusCode.Unknown:
                     break;
                 case ResponseEnvelope.Types.StatusCode.Ok:

--- a/Rpc/Login.cs
+++ b/Rpc/Login.cs
@@ -122,7 +122,12 @@ namespace PokemonGo.RocketAPI.Rpc
 
                         if (tries == 5)
                         {
-                            throw new LoginFailedException("Error refreshing access token.");
+
+                            var cacheDir = Path.Combine(Directory.GetCurrentDirectory(), "Cache");
+                            var fileName = Path.Combine(cacheDir, $"{client.AccessToken?.Uid}-{client.LoginProvider.ProviderId}.json");
+                            File.Delete(fileName);
+
+                            throw new TokenRefreshException("Error refreshing access token.");
                         }
                     }
                 }

--- a/Rpc/Player.cs
+++ b/Rpc/Player.cs
@@ -38,7 +38,7 @@ namespace PokemonGo.RocketAPI.Rpc
                 {
                     RequestType = RequestType.PlayerUpdate,
                     RequestMessage = message.ToByteString()
-                }   ,
+                },
                 new Request
                 {
                     RequestType = RequestType.CheckChallenge,
@@ -46,8 +46,8 @@ namespace PokemonGo.RocketAPI.Rpc
                 }
             });
 
-            var tuple = await PostProtoPayload<Request, PlayerUpdateResponse,CheckChallengeResponse>(updatePlayerLocationRequestEnvelope);
-            if(tuple.Item2.ShowChallenge && string.IsNullOrEmpty(tuple.Item2.ChallengeUrl))
+            var tuple = await PostProtoPayload<Request, PlayerUpdateResponse, CheckChallengeResponse>(updatePlayerLocationRequestEnvelope);
+            if (tuple.Item2.ShowChallenge && string.IsNullOrEmpty(tuple.Item2.ChallengeUrl))
             {
                 throw new CaptchaException(tuple.Item2.ChallengeUrl);
             }

--- a/Rpc/Player.cs
+++ b/Rpc/Player.cs
@@ -9,6 +9,7 @@ using POGOProtos.Networking.Requests.Messages;
 using POGOProtos.Networking.Responses;
 using System;
 using PokemonGo.RocketAPI.Helpers;
+using PokemonGo.RocketAPI.Exceptions;
 
 #endregion
 
@@ -37,10 +38,21 @@ namespace PokemonGo.RocketAPI.Rpc
                 {
                     RequestType = RequestType.PlayerUpdate,
                     RequestMessage = message.ToByteString()
+                }   ,
+                new Request
+                {
+                    RequestType = RequestType.CheckChallenge,
+                    RequestMessage = (new CheckChallengeMessage()).ToByteString() 
                 }
             });
 
-            return await PostProtoPayload<Request, PlayerUpdateResponse>(updatePlayerLocationRequestEnvelope);
+            var tuple = await PostProtoPayload<Request, PlayerUpdateResponse,CheckChallengeResponse>(updatePlayerLocationRequestEnvelope);
+            if(tuple.Item2.ShowChallenge && string.IsNullOrEmpty(tuple.Item2.ChallengeUrl))
+            {
+                throw new CaptchaException(tuple.Item2.ChallengeUrl);
+            }
+
+            return tuple.Item1;
         }
 
         internal void SetCoordinates(double lat, double lng, double altitude)


### PR DESCRIPTION
Some people has issue with Token expired then re authentication unsuccessful after 5 retry and throw LoginFailedException, on logic we consider it as Ban then stop. Logic layer will try to relogin if this case happy, if multibot enable, it will switch to nextbot

Also Bad Request consider as LoginInvalidException, I change them to display more info for debug, Bad Request maybe related to inventory change recently. This is critical issue and we need fix asap.



