### PR TITLE
Implement fix for hash server rounding bug by using new 64-bit params

### DIFF
--- a/Hash/HashModel.cs
+++ b/Hash/HashModel.cs
@@ -29,17 +29,17 @@ namespace PokemonGo.RocketAPI.Hash
         /// The Latitude field from your ClientRpc request envelope. (The one you will be sending to Niantic)
         /// For safety reasons, this should also match your last LocationUpdate entry in the SignalLog
         /// </summary>
-        public double Latitude { get; set; }
+        public Int64 Latitude64 { get; set; }
         /// <summary>
         /// The Longitude field from your ClientRpc request envelope. (The one you will be sending to Niantic)
         /// For safety reasons, this should also match your last LocationUpdate entry in the SignalLog
         /// </summary>
-        public double Longitude { get; set; }
+        public Int64 Longitude64 { get; set; }
         /// <summary>
         /// The Altitude field from your ClientRpc request envelope. (The one you will be sending to Niantic)
         /// For safety reasons, this should also match your last LocationUpdate entry in the SignalLog
         /// </summary>
-        public double Altitude { get; set; }
+        public Int64 Accuracy64 { get; set; }
 
         /// <summary>
         ///     The Niantic-specific auth ticket data.

--- a/Hash/LegacyHashser.cs
+++ b/Hash/LegacyHashser.cs
@@ -15,9 +15,8 @@ namespace PokemonGo.RocketAPI.Hash
 
             var hashed = new HashResponseContent()
             {
-
-                LocationAuthHash =  Utils.GenerateLocation1(request.AuthTicket, request.Latitude, request.Longitude, request.Altitude),
-                LocationHash = Utils.GenerateLocation2(request.Latitude, request.Longitude, request.Altitude),
+                LocationAuthHash =  Utils.GenerateLocation1(request.AuthTicket, BitConverter.Int64BitsToDouble(request.Latitude64), BitConverter.Int64BitsToDouble(request.Longitude64), BitConverter.Int64BitsToDouble(request.Accuracy64)),
+                LocationHash = Utils.GenerateLocation2(BitConverter.Int64BitsToDouble(request.Latitude64), BitConverter.Int64BitsToDouble(request.Longitude64), BitConverter.Int64BitsToDouble(request.Accuracy64)),
                 RequestHashes = new List<long>()
             };
             foreach (var req in request.Requests)

--- a/Helpers/RequestBuilder.cs
+++ b/Helpers/RequestBuilder.cs
@@ -195,9 +195,9 @@ namespace PokemonGo.RocketAPI.Helpers
 
             HashRequestContent hashRequest = new HashRequestContent()
             {
-                Latitude = currentLocation.Latitude,
-                Longitude = currentLocation.Longitude,
-                Altitude = requestEnvelope.Accuracy,
+                Latitude64 = BitConverter.DoubleToInt64Bits(currentLocation.Latitude),
+                Longitude64 = BitConverter.DoubleToInt64Bits(currentLocation.Longitude),
+                Accuracy64 = BitConverter.DoubleToInt64Bits(requestEnvelope.Accuracy),
                 AuthTicket = ticketBytes,
                 SessionData = _sessionHash.ToByteArray(),
                 Requests = new List<byte[]>(),


### PR DESCRIPTION
This rounding error was causing session invalidation errors to be returned by the API.