### PR TITLE
Revert back to 0.57.4 API

### DIFF
--- a/Client.cs
+++ b/Client.cs
@@ -25,7 +25,7 @@ namespace PokemonGo.RocketAPI
     public class Client : ICaptchaResponseHandler
     {
         public static string API_VERSION = "0.57.4";
-		// public static string API_VERSION = "0.59.1"; // 0.59.1
+        // public static string API_VERSION = "0.59.1"; // 0.59.1
 
         public static WebProxy Proxy;
 
@@ -81,7 +81,7 @@ namespace PokemonGo.RocketAPI
                 if (string.IsNullOrEmpty(settings.AuthAPIKey)) throw new AuthConfigException("You have selected Pogodev API but not provide proper API Key");
 
                 Cryptor = new Crypt();
-				// Cryptor = new Crypto(); // 0.59.1
+                // Cryptor = new Crypto(); // 0.59.1
 
                 // This value will determine which version of the hashing service you will receive.
                 // Currently supported versions:
@@ -95,16 +95,18 @@ namespace PokemonGo.RocketAPI
                 // v129_1 -> Pogo iOS 1.29.1
 
                 ApiEndPoint = "api/v127_4/hash";
-				// ApiEndPoint = "api/v129_1/hash"; // 0.59.1
+                // ApiEndPoint = "api/v129_1/hash"; // 0.59.1
+		
                 Hasher = new PokefamerHasher(settings.AuthAPIKey, settings.DisplayVerboseLog, ApiEndPoint);
 
                 // These 4 constants below need to change if we update the hashing server API version that is used.
                 Unknown25 = -816976800928766045;
-				// Unknown25 = -3226782243204485589; // 0.59.1
+                // Unknown25 = -3226782243204485589; // 0.59.1
 				
-				// WARNING! IF YOU CHANGE THE APPVERSION BELOW ALSO UPDATE THE API_VERSION AT THE TOP OF THE FILE!
+                // WARNING! IF YOU CHANGE THE APPVERSION BELOW ALSO UPDATE THE API_VERSION AT THE TOP OF THE FILE!
                 AppVersion = 5704;
                 // AppVersion = 5901; // 0.59.1
+		
                 CurrentApiEmulationVersion = new Version(API_VERSION);
                 UnknownPlat8Field = "90f6a704505bccac73cec99b07794993e6fd5a12";
             }

--- a/Client.cs
+++ b/Client.cs
@@ -24,7 +24,8 @@ namespace PokemonGo.RocketAPI
 {
     public class Client : ICaptchaResponseHandler
     {
-        public static string API_VERSION = "0.59.1";
+        public static string API_VERSION = "0.57.4";
+		// public static string API_VERSION = "0.59.1"; // 0.59.1
 
         public static WebProxy Proxy;
 
@@ -79,7 +80,8 @@ namespace PokemonGo.RocketAPI
             {
                 if (string.IsNullOrEmpty(settings.AuthAPIKey)) throw new AuthConfigException("You have selected Pogodev API but not provide proper API Key");
 
-                Cryptor = new Crypto();
+                Cryptor = new Crypt();
+				// Cryptor = new Crypto(); // 0.59.1
 
                 // This value will determine which version of the hashing service you will receive.
                 // Currently supported versions:
@@ -92,14 +94,17 @@ namespace PokemonGo.RocketAPI
                 // v127_4 -> Pogo iOS 1.27.4
                 // v129_1 -> Pogo iOS 1.29.1
 
-                ApiEndPoint = "api/v129_1/hash";
+                ApiEndPoint = "api/v127_4/hash";
+				// ApiEndPoint = "api/v129_1/hash"; // 0.59.1
                 Hasher = new PokefamerHasher(settings.AuthAPIKey, settings.DisplayVerboseLog, ApiEndPoint);
 
                 // These 4 constants below need to change if we update the hashing server API version that is used.
-                Unknown25 = -3226782243204485589;
-
-                // WARNING! IF YOU CHANGE THE APPVERSION BELOW ALSO UPDATE THE API_VERSION AT THE TOP OF THE FILE!
-                AppVersion = 5901;
+                Unknown25 = -816976800928766045;
+				// Unknown25 = -3226782243204485589; // 0.59.1
+				
+				// WARNING! IF YOU CHANGE THE APPVERSION BELOW ALSO UPDATE THE API_VERSION AT THE TOP OF THE FILE!
+                AppVersion = 5704;
+                // AppVersion = 5901; // 0.59.1
                 CurrentApiEmulationVersion = new Version(API_VERSION);
                 UnknownPlat8Field = "90f6a704505bccac73cec99b07794993e6fd5a12";
             }


### PR DESCRIPTION
Move back to 0.57.4 API for now until we figure out what's going on with session invalidation errors in 0.59.1 API.